### PR TITLE
Add a WP transient backend implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ This is the default backend which writes the cache to
 `/tmp/wp-graphql-cache`. It not super fast but it can perform reasonably when
 backed by a RAM disk.
 
+### Transient
+
+This is cache storage backend which writes WordPress transients.
+
+This is a flexible cache storage backend as the true storage can be 
+configured at a platform level via the use of the object cache. By default 
+if no object cache is defined WordPress will store transients as options in
+the database. 
+
+For example a single server environment might use a APC object cache where as
+a HA environment might have a Memcached or Redis backend.
+
 ### OPCache
 
 TODO

--- a/src/Backend/Transient.php
+++ b/src/Backend/Transient.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPGraphQL\Extensions\Cache\Backend;
+
+use WPGraphQL\Extensions\Cache\CachedValue;
+
+/**
+ * WPGraphQL Cache transients backend.
+ *
+ * By default WordPress will store transients as options in the database. However when an object-cache
+ * is installed this will be stored in the object cache backend. This is the most flexible cache storage
+ * backend in WordPress as the true backend storage can be configured at a platform level.
+ *
+ * For example a single server environment might use a APC object cache where as a HA environment might
+ * have a Memcached or Redis backend.
+ */
+class Transient extends AbstractBackend
+{
+
+	protected $cached_value;
+
+	function set(string $zone, string $key, CachedValue $cached_value, $expire = null): void
+	{
+
+		$cached_value_serialized = serialize($cached_value);
+
+		$transient_key = $this->get_transient_key($zone, $key);
+
+		set_transient($transient_key, $cached_value_serialized, $expire);
+
+		$this->add_zone($zone);
+		$this->add_key_to_zone($zone, $key);
+
+	}
+
+	function get(string $zone, string $key): ?CachedValue
+    {
+
+		$transient_key = $this->get_transient_key($zone, $key);
+
+		$cached_value_serialized = get_transient($transient_key);
+		if ( $cached_value_serialized ) {
+
+			$cached_value = unserialize($cached_value_serialized);
+			if ( $cached_value ) {
+
+				$this->cached_value = $cached_value;
+			}
+		}
+
+		return $this->cached_value;
+
+	}
+
+	function delete(string $zone, string $cache_key): bool
+    {
+
+		$transient_key = $this->get_transient_key($zone, $cache_key);
+
+		return delete_transient( $transient_key );
+
+	}
+
+	function clear_zone(string $zone): bool
+    {
+
+		$deleted = false;
+
+		$zone_cache_keys = $this->get_keys_in_zone($zone);
+		foreach ($zone_cache_keys as $cache_key) {
+			$transient_key = $this->get_transient_key($zone, $cache_key);
+			$deleted = $deleted || $this->delete($zone, $transient_key);
+		}
+
+		return $deleted;
+
+	}
+
+	function clear(): bool
+    {
+		
+		$deleted = false;
+
+		$zones = $this->get_zones();
+		foreach ($zones as $zone) {
+			if ( $zone && is_string($zone) ) {
+				$deleted = $deleted || $this->clear_zone($zone);
+			}
+		}
+
+		return $deleted;
+
+	}
+
+	/**
+	 * Add the given zone to the list of known zones.
+	 *
+	 * @param string $zone The cache zone.
+	 */
+	protected function add_zone(string $zone): void
+	{
+
+		$zone_list_transient_key = $this->get_zone_list_transient_key($zone);
+
+		// Add the cache key to the list of known cache keys for the zone.
+		$zones = $this->get_zones($zone);
+		$zones[] = $zone;
+		$zones = array_unique( $zones );
+
+		// Store the updated list of zone cache keys.
+		set_transient($zone_list_transient_key, $zones);
+
+	}
+
+	/**
+	 * Get all known cache zones.
+	 *
+	 * @return array
+	 */
+	protected function get_zones(): array
+	{
+
+		$zone_list_transient_key = $this->get_zone_list_transient_key($zone);
+
+		$zone_list_transient_value = get_transient($zone_list_transient_key);
+		if (!$zone_list_transient_value || !is_array($zone_list_transient_value)) {
+			$zone_list_transient_value = array();
+		}
+
+		return $zone_list_transient_value;
+
+	}
+
+	/**
+	 * Add the given cache key to the list of known cache keys associated with the given cache zone.
+	 *
+	 * @param string $zone The cache zone.
+	 * @param string $cache_key The cache key.
+	 */
+	protected function add_key_to_zone(string $zone, string $cache_key): void
+	{
+
+		$zone_transient_key = $this->get_zone_transient_key($zone);
+
+		// Add the cache key to the list of known cache keys for the zone.
+		$zone_keys = $this->get_keys_in_zone($zone);
+		$zone_keys[] = $cache_key;
+		$zone_keys = array_unique( $zone_keys );
+
+		// Store the updated list of zone cache keys.
+		set_transient($zone_transient_key, $zone_keys);
+
+	}
+
+	/**
+	 * Get all cache keys known to be associated with the given cache zone.
+	 *
+	 * @param string $zone The cache zone.
+	 * @return array
+	 */
+	protected function get_keys_in_zone(string $zone): array
+	{
+
+		$zone_transient_key = $this->get_zone_transient_key($zone);
+
+		$zone_transient_value = get_transient($zone_transient_key);
+		if (!$zone_transient_value || !is_array($zone_transient_value)) {
+			$zone_transient_value = array();
+		}
+
+		return $zone_transient_value;
+
+	}
+
+	/**
+	 * Get the transient key used to store all known zones.
+	 * I.e. via the use of add_zone().
+	 *
+	 * @return string
+	 */
+	protected function get_zone_list_transient_key(): string
+	{
+
+		return 'wp-graphql-zones';
+
+	}
+
+	/**
+	 * Translate the given zone name to the transient key used to store the cache keys associated with it.
+	 * I.e. via the use of add_key_to_zone().
+	 *
+	 * @param string $zone The cache zone.
+	 * @return string
+	 */
+	protected function get_zone_transient_key(string $zone): string
+	{
+
+		$zone_transient_key = sprintf(
+			'wp-graphql-zone-%s',
+			md5($zone)
+		);
+
+		return $zone_transient_key;
+
+	}
+
+	/**
+	 * Translate the zone & cache key to the transient key we use to store the cached value.
+	 *
+	 * @param string $zone The cache zone.
+	 * @param string $cache_key The cache key.
+	 * @return string
+	 */
+	protected function get_transient_key(string $zone, string $cache_key): string
+	{
+
+		// Hash the real cache key to ensure the transient key will always be below the limit of 172 characters.
+		$transient_key = sprintf(
+			'wp-graphql-cache-%s',
+			md5($zone),
+			md5($cache_key)
+		);
+
+		return $transient_key;
+
+	}
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -10,6 +10,7 @@ return array(
     'WPGraphQL\\Extensions\\Cache\\Backend\\AbstractBackend' => $baseDir . '/src/Backend/AbstractBackend.php',
     'WPGraphQL\\Extensions\\Cache\\Backend\\FileSystem' => $baseDir . '/src/Backend/FileSystem.php',
     'WPGraphQL\\Extensions\\Cache\\Backend\\OPCache' => $baseDir . '/src/Backend/OPCache.php',
+    'WPGraphQL\\Extensions\\Cache\\Backend\\Transient' => $baseDir . '/src/Backend/Transient.php',
     'WPGraphQL\\Extensions\\Cache\\CacheManager' => $baseDir . '/src/CacheManager.php',
     'WPGraphQL\\Extensions\\Cache\\CachedValue' => $baseDir . '/src/CachedValue.php',
     'WPGraphQL\\Extensions\\Cache\\FieldCache' => $baseDir . '/src/FieldCache.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -25,6 +25,7 @@ class ComposerStaticInita74333163ecc514adfca7ffa2a27ffad
         'WPGraphQL\\Extensions\\Cache\\Backend\\AbstractBackend' => __DIR__ . '/../..' . '/src/Backend/AbstractBackend.php',
         'WPGraphQL\\Extensions\\Cache\\Backend\\FileSystem' => __DIR__ . '/../..' . '/src/Backend/FileSystem.php',
         'WPGraphQL\\Extensions\\Cache\\Backend\\OPCache' => __DIR__ . '/../..' . '/src/Backend/OPCache.php',
+        'WPGraphQL\\Extensions\\Cache\\Backend\\Transient' => __DIR__ . '/../..' . '/src/Backend/Transient.php',
         'WPGraphQL\\Extensions\\Cache\\CacheManager' => __DIR__ . '/../..' . '/src/CacheManager.php',
         'WPGraphQL\\Extensions\\Cache\\CachedValue' => __DIR__ . '/../..' . '/src/CachedValue.php',
         'WPGraphQL\\Extensions\\Cache\\FieldCache' => __DIR__ . '/../..' . '/src/FieldCache.php',


### PR DESCRIPTION
Add a new cache backend which uses WordPress transients as a data store.

This is a flexible cache storage backend as the true storage can be configured at a platform level via the use of the object cache. 
For example a single server environment might use a APC object cache where as a HA environment might have a Memcached or Redis backend.

Additionally there is a fallback to the default WP behavior of storing transients in the database as options if no object cache is defined. Unlike with wp_cache_set() etc., which would just fail is no object cache was defined.

I have tested this with the following:

- WP core v5.6
- WP-GraphQL v1.1.2 (latest)