### PR TITLE
Update field cache to allow it to be used wihtout the query_name

### DIFF
--- a/src/FieldCache.php
+++ b/src/FieldCache.php
@@ -101,12 +101,12 @@ class FieldCache extends AbstractCache
         if (count($info->path) !== 1) {
             return $nil;
         }
-		
+
         // Check it matches with configured field name
         if ($this->field_name !== $info->path[0]) {
             return $nil;
         }
-	
+
         // Mark as mached ie. this field should be cached
         $this->match = true;
 

--- a/src/FieldCache.php
+++ b/src/FieldCache.php
@@ -75,16 +75,9 @@ class FieldCache extends AbstractCache
 
     function __action_do_graphql_request(string $query, $operation_name)
     {
-        // Capture from operation name if available
-        if ($operation_name === $this->query_name) {
-            $this->query = $query;
-            return;
-        }
 
-        $current_query_name = Utils::get_query_name($query);
-        if ($current_query_name === $this->query_name) {
-            $this->query = $query;
-        }
+		$this->query = $query;
+
     }
 
     function __filter_graphql_pre_resolve_field(
@@ -98,6 +91,7 @@ class FieldCache extends AbstractCache
         $field,
         $field_resolver
     ) {
+
         // No query, no query name match
         if (!$this->query) {
             return $nil;
@@ -107,22 +101,31 @@ class FieldCache extends AbstractCache
         if (count($info->path) !== 1) {
             return $nil;
         }
-
+		
         // Check it matches with configured field name
         if ($this->field_name !== $info->path[0]) {
             return $nil;
         }
-
+	
         // Mark as mached ie. this field should be cached
         $this->match = true;
 
-        $query_name = Utils::sanitize($this->query_name);
         $field_name = Utils::sanitize($this->field_name);
         $args_hash = Utils::hash(Utils::stable_string($args));
-        $query_hash = Utils::hash($this->query);
         $user_id = get_current_user_id();
 
-        $this->key = "field-{$query_name}-${field_name}-${user_id}-{$query_hash}-${args_hash}";
+		if ( $this->query_name ) {
+			// If query name is configured, include the query hash in the cache key.
+
+			$query_name = Utils::sanitize($this->query_name);
+			$query_hash = Utils::hash($this->query);
+
+			$this->key = "field-${query_name}-${field_name}-${user_id}-${query_hash}-${args_hash}";
+		} else {
+			// If query name is not configured, do not include the query hash in the cache key.
+
+			$this->key = "field-${field_name}-${user_id}-${args_hash}";
+		}
 
         $this->read_cache();
 


### PR DESCRIPTION
Update field caching to work across multiple queries.

This PR allows a field cache to be configured across multiple / all queries. When the `query_name` parameter is omitted, a field cache will be global and not tied to a specific query at all.

This is useful for caching fields which are included across multiple queries. An example from a project I am working on is the menus, which are included in every query we do. I can configure a field cache like so and have it computed on once globally for all of our queries.

E.g. 

```
CacheManager::register_graphql_field_cache(
	array(
		'zone'       => 'menus',
		'field_name' => 'headerMenus',
		'expire'     => 600, // seconds.
	)
);
```

This is still compatible with fields configured with a `query_name` and will function exactly as it does currently.
